### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # GitStats
 A simple PreactJS app that uses the GitHub search API to display repositories in a list.
 
+![Travis Build Status](https://img.shields.io/travis/ivanseed/gitstats.svg "Build Status")
+![Code Climate](https://img.shields.io/codeclimate/github/ivanseed/gitstats.svg "Code Climate")
+
 ## Running
 `npm install` then `npm run start`
 


### PR DESCRIPTION
Improves #21 by adding build status and code climate badges to the README