### PR TITLE
Fix for issue #32 - change updated_at to pushed_at. Reason: pushed_at…

### DIFF
--- a/src/components/repository.js
+++ b/src/components/repository.js
@@ -26,8 +26,8 @@ const repository =  ({item}) => (
     </div>
     <div className="repository-time">
       <TimeIcon />
-      <span>{format(item.updated_at, 'HH:mm:ss')}</span>
-      <span>{format(item.updated_at, 'YYYY/MM/DD')}</span>
+      <span>{format(item.pushed_at, 'HH:mm:ss')}</span>
+      <span>{format(item.pushed_at, 'YYYY/MM/DD')}</span>
     </div>
   </div>
 );


### PR DESCRIPTION
… will be updated any time a commit is pushed to any of the repository's branches. updated_at will be updated any time the repository object is updated, e.g. when the description or the primary language of the repository is updated. It's not necessary that a push will update the updated_at attribute -- that will only happen if a push triggers an update to the repository object.