### PR TITLE
Disable spellcheck on search field.

### DIFF
--- a/src/components/search-bar.js
+++ b/src/components/search-bar.js
@@ -42,6 +42,7 @@ export default class SearchBar extends Component {
             className="search-bar"
             placeholder="Search..."
             value={query}
+            spellcheck="false"
             onChange={event => this.onInputChange(event.target.value)}
           />
           <img


### PR DESCRIPTION
Disables `spellcheck` field on `input.search-bar` element.

__Before:__
<img width="167" alt="screen shot 2017-10-13 at 9 39 51 am" src="https://user-images.githubusercontent.com/16392483/31522626-86bd56e0-affa-11e7-9bd3-3dc7f1580ad5.png">

__After:__
<img width="167" alt="screen shot 2017-10-13 at 9 40 00 am" src="https://user-images.githubusercontent.com/16392483/31522628-8959193e-affa-11e7-95ed-b193c3c0b332.png">

Tested in chrome.
