### PR TITLE
Added support for GitHub Emojis (#63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "axios": "^0.16.2",
     "date-fns": "^1.28.5",
+    "node-emoji": "^1.8.1",
     "preact": "^8.2.5",
     "preact-compat": "^3.17.0",
     "preact-helmet": "^4.0.0-alpha-3",

--- a/src/components/repository.js
+++ b/src/components/repository.js
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import format from 'date-fns/format';
+import emoji from 'node-emoji';
 import {
   StarIcon,
   RepoForkedIcon,
@@ -21,7 +22,7 @@ const Repository =  ({ item }) => (
         <span>{item.owner.login}/<b>{item.name}</b></span>
       </div>
       <div className="repository-description">
-        <span>{item.description}</span>
+        <span>{emoji.emojify(item.description, () => { return '' })}</span>
       </div>
       <div class="repository-meta-container">
         <div>


### PR DESCRIPTION
This has been done with node-emoji. 

`emoji.emojify(item.description, () => { return '' }`

This will take the description and replace any emoji keywords like `:books:` and replace it with the appropriate emoji :books:.

In the rare event that an emoji doesn't exist, such as :atom:, it will replace `:atom:` with an empty string until the emoji is supported.