### PR TITLE
Render emojis in project descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitstats",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9224,15 +9224,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -9241,6 +9232,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "preact": "^8.2.5",
     "preact-compat": "^3.17.0",
     "preact-helmet": "^4.0.0-alpha-3",
+    "react-emoji-render": "^0.4.2",
     "react-octicons": "^0.2.0"
   }
 }

--- a/src/components/repository.js
+++ b/src/components/repository.js
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import format from 'date-fns/format';
+import Emoji from 'react-emoji-render';
 import {
   StarIcon,
   RepoForkedIcon,
@@ -21,7 +22,7 @@ const Repository =  ({ item }) => (
         <span>{item.owner.login}/<b>{item.name}</b></span>
       </div>
       <div className="repository-description">
-        <span>{item.description}</span>
+        <Emoji text={item.description} />
       </div>
       <div class="repository-meta-container">
         <div>


### PR DESCRIPTION
This is an alternative to #67 (which was opened while I was implementing this PR). This approach uses the React component provided by [react-emoji-render](https://github.com/tommoor/react-emoji-render) to render the emojis in the project descriptions.

Using a component over an inline function has the advantage that it's slightly more readable/declarative and also avoids re-renders of the component on every cycle since React can figure out that the props of the Emoji component haven't changed since the last render.

Here is an example of a project description being rendered with an emoji:

![image](https://user-images.githubusercontent.com/1086421/31523675-e9bbce02-af82-11e7-9b5d-01d8021652a0.png)

Resolves #63