### PR TITLE
#49 Fix for jaggered loading bar

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -38,6 +38,9 @@ export default class App extends Component {
         });
       })
       .catch((err) => {
+          this.setState({
+              'progress': 'end'
+          });
         console.log('gota error');
       });
   }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -38,9 +38,9 @@ export default class App extends Component {
         });
       })
       .catch((err) => {
-          this.setState({
-              'progress': 'end'
-          });
+        this.setState({
+          'progress': 'end'
+        });
         console.log('gota error');
       });
   }

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -13,7 +13,7 @@ export default class Progress extends Component {
     const growSize = 100;
 
     // Don't complete the loading bar until we are actually complete
-    if (this.state.width + growSize < this.state.maxWidth) {
+    if (((this.state.width + growSize) < this.state.maxWidth) && this.props.status === 'start') {
       this.setState({
         width: this.state.width + growSize
       });
@@ -33,7 +33,7 @@ export default class Progress extends Component {
   stopAnimation = () => {
     clearInterval(this.updateInterval);
     this.updateInterval = false;
-    setTimeout(this.resetProgressSize, 300);
+    this.resetProgressSize();
   }
 
   updateWindowDimensions = () => {
@@ -46,7 +46,7 @@ export default class Progress extends Component {
   }
 
   componentDidUpdate() {
-    if (this.props.status === 'end') {
+    if (this.props.status === 'end' && this.updateInterval) {
       this.stopAnimation();
     } else if (this.props.status === 'start' && !this.updateInterval) {
       this.startAnimation();

--- a/src/style/progress.css
+++ b/src/style/progress.css
@@ -56,5 +56,6 @@
 
 @keyframes progress--load--end {
     80% { width: 100%; opacity: 1;}
-    100% { width: 100%; opacity: 0; }
+    99% { width: 100%; opacity: 0; }
+    100% { width: 0; opacity: 0; }
 }


### PR DESCRIPTION
#49 
My colleague @fragkp reserved this issue for me.
I added some conditions that prevent the width from jumping between 100px and 0px.
I also fixed it for Firefox by resetting the width after the progress--load--end key frame.